### PR TITLE
Fix leaderboard commands

### DIFF
--- a/commands/help.py
+++ b/commands/help.py
@@ -46,10 +46,8 @@ class HelpCommand(commands.Cog):
         help_embed.add_field(
             name="Leaderboard Commands",
             value=(
-                "**!leaderboard** - View MMR leaderboard\n"
-                # "**!leaderboard_KD** - View K/D leaderboard\n"
-                # "**!leaderboard_wins** - View wins leaderboard\n"
-                # "**!leaderboard_ACS** - View ACS leaderboard\n"
+                "**!leaderboard <type>** - View the leaderboard\n"
+                "↪ _Available types: `mmr` (default), `wins`, `losses`, `kd`, `acs`_\n"
             ),
             inline=False,
         )

--- a/commands/leaderboard_commands.py
+++ b/commands/leaderboard_commands.py
@@ -6,9 +6,6 @@ from commands import BotCommands
 from database import users, mmr_collection
 from views.leaderboard_view import (
     LeaderboardView,
-    LeaderboardViewKD,
-    LeaderboardViewWins,
-    LeaderboardViewACS,
 )
 import wcwidth
 from table2ascii import table2ascii as t2a, PresetStyle
@@ -20,272 +17,32 @@ async def setup(bot):
 
 class LeaderboardCommands(BotCommands):
     @commands.command()
-    async def leaderboard(self, ctx):
+    async def leaderboard(self, ctx, sort_by: str = "mmr"):
+        valid_sort_map = {
+            "mmr": "mmr",
+            "acs": "average_combat_score",
+            "kd": "kill_death_ratio",
+            "wins": "wins",
+            "losses": "losses"
+        }
+
+        sort_by = sort_by.lower()
+
+        if sort_by not in valid_sort_map:
+            await ctx.send("Invalid leaderboard type.")
+            return
+
+        sort_by_internal = valid_sort_map[sort_by]
+
         cursor = mmr_collection.find()
         sorted_data = list(cursor)
-        sorted_data.sort(key=lambda x: x.get("mmr", 0), reverse=True)
+        sorted_data.sort(key=lambda x: x.get(sort_by_internal, 0), reverse=True)
 
         self.leaderboard_view = LeaderboardView(
-            ctx, self.bot, sorted_data, players_per_page=10, timeout=None, mode="normal"
+            ctx, self.bot, sorted_data, sort_by_internal, players_per_page=10, timeout=None, mode="normal"
         )
-
-        start_index = 0
-        end_index = min(
-            self.leaderboard_view.players_per_page,
-            len(self.leaderboard_view.sorted_data),
-        )
-        page_data = self.leaderboard_view.sorted_data[start_index:end_index]
-
-        # Create initial leaderboard table
-        leaderboard_data = []
-        for idx, stats in enumerate(page_data, start=1):
-            user_data = users.find_one({"discord_id": str(stats["player_id"])})
-            if user_data:
-                full_name = f"{user_data.get('name', 'Unknown')}#{user_data.get('tag', 'Unknown')}"
-                if wcwidth.wcswidth(full_name) > 20:
-                    name = full_name[:17] + "..."
-                else:
-                    name = full_name.ljust(20)
-            else:
-                name = "Unknown"
-
-            leaderboard_data.append(
-                [
-                    idx,
-                    name,
-                    stats.get("mmr", 1000),
-                    stats.get("wins", 0),
-                    stats.get("losses", 0),
-                    f"{stats.get('average_combat_score', 0):.2f}",
-                    f"{stats.get('kill_death_ratio', 0):.2f}",
-                ]
-            )
-
-        table_output = t2a(
-            header=["Rank", "User", "MMR", "Wins", "Losses", "Avg ACS", "K/D"],
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        content = f"## MMR Leaderboard (Page 1/{self.leaderboard_view.total_pages}) ##\n```\n{table_output}\n```"
 
         self.leaderboard_message = await ctx.send(
-            content=content, view=self.leaderboard_view
+            content=self.leaderboard_view.make_content(sorted_data, "normal", self.leaderboard_view.total_pages), view=self.leaderboard_view
         )
 
-    @commands.command()
-    async def leaderboard_KD(self, ctx):
-        if not self.bot.player_mmr:
-            await ctx.send("No MMR data available yet.")
-            return
-
-        # Sort all players by MMR
-        sorted_kd = sorted(
-            self.bot.player_mmr.items(),
-            key=lambda x: x[1].get("kill_death_ratio", 0.0),
-            reverse=True,
-        )
-
-        # Create the view for pages
-        view = LeaderboardView(ctx, self.bot, sorted_kd, players_per_page=10)
-
-        # Calculate the page indexes
-        start_index = view.current_page * view.players_per_page
-        end_index = start_index + view.players_per_page
-        page_data = sorted_kd[start_index:end_index]
-
-        names = []
-        leaderboard_data = []
-        for player_id, stats in page_data:
-            user_data = users.find_one({"discord_id": str(player_id)})
-            if user_data:
-                riot_name = user_data.get("name", "Unknown")
-                riot_tag = user_data.get("tag", "Unknown")
-                names.append(f"{riot_name}#{riot_tag}")
-            else:
-                names.append("Unknown")
-
-        # Stats for leaderboard
-        for idx, ((player_id, stats), name) in enumerate(
-            zip(page_data, names), start=start_index + 1
-        ):
-            mmr_value = stats["mmr"]
-            wins = stats["wins"]
-            losses = stats["losses"]
-            matches_played = stats.get("matches_played", wins + losses)
-            avg_cs = stats.get("average_combat_score", 0)
-            kd_ratio = stats.get("kill_death_ratio", 0)
-            win_percent = (wins / matches_played * 100) if matches_played > 0 else 0
-
-            leaderboard_data.append(
-                [
-                    idx,
-                    name,
-                    f"{kd_ratio:.2f}",
-                    mmr_value,
-                    wins,
-                    losses,
-                    f"{win_percent:.2f}",
-                    f"{avg_cs:.2f}",
-                ]
-            )
-
-        table_output = t2a(
-            header=["Rank", "User", "K/D", "MMR", "Wins", "Losses", "Win%", "Avg ACS"],
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        self.leaderboard_view_kd = LeaderboardViewKD(
-            ctx, self.bot, sorted_kd, players_per_page=10, timeout=None
-        )
-
-        content = f"## K/D Leaderboard (Page {self.leaderboard_view_kd.current_page+1}/{self.leaderboard_view_kd.total_pages}) ##\n```\n{table_output}\n```"
-        self.leaderboard_message_kd = await ctx.send(
-            content=content, view=self.leaderboard_view_kd
-        )
-
-    @commands.command()
-    async def leaderboard_wins(self, ctx):
-        if not self.bot.player_mmr:
-            await ctx.send("No MMR data available yet.")
-            return
-
-        # Sort all players by wins
-        sorted_wins = sorted(
-            self.bot.player_mmr.items(),
-            key=lambda x: x[1].get("wins", 0.0),
-            reverse=True,
-        )
-
-        # Create the view for pages
-        view = LeaderboardView(ctx, self.bot, sorted_wins, players_per_page=10)
-
-        # Calculate the page indexes
-        start_index = view.current_page * view.players_per_page
-        end_index = start_index + view.players_per_page
-        page_data = sorted_wins[start_index:end_index]
-
-        names = []
-        leaderboard_data = []
-        for player_id, stats in page_data:
-            user_data = users.find_one({"discord_id": str(player_id)})
-            if user_data:
-                riot_name = user_data.get("name", "Unknown")
-                riot_tag = user_data.get("tag", "Unknown")
-                names.append(f"{riot_name}#{riot_tag}")
-            else:
-                names.append("Unknown")
-
-        for idx, ((player_id, stats), name) in enumerate(
-            zip(page_data, names), start=start_index + 1
-        ):
-            mmr_value = stats["mmr"]
-            wins = stats["wins"]
-            losses = stats["losses"]
-            matches_played = stats.get("matches_played", wins + losses)
-            avg_cs = stats.get("average_combat_score", 0)
-            kd_ratio = stats.get("kill_death_ratio", 0)
-            win_percent = (wins / matches_played * 100) if matches_played > 0 else 0
-
-            leaderboard_data.append(
-                [
-                    idx,
-                    name,
-                    wins,
-                    mmr_value,
-                    losses,
-                    f"{win_percent:.2f}",
-                    f"{avg_cs:.2f}",
-                    f"{kd_ratio:.2f}",
-                ]
-            )
-
-        table_output = t2a(
-            header=["Rank", "User", "Wins", "MMR", "Losses", "Win%", "Avg ACS", "K/D"],
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        self.leaderboard_view_wins = LeaderboardViewWins(
-            ctx, self.bot, sorted_wins, players_per_page=10, timeout=None
-        )
-
-        content = f"## Wins Leaderboard (Page {self.leaderboard_view_wins.current_page+1}/{self.leaderboard_view_wins.total_pages}) ##\n```\n{table_output}\n```"
-        self.leaderboard_message_wins = await ctx.send(
-            content=content, view=self.leaderboard_view_wins
-        )
-
-    @commands.command()
-    async def leaderboard_ACS(self, ctx):
-        if not self.bot.player_mmr:
-            await ctx.send("No MMR data available yet.")
-            return
-
-        # Sort all players by ACS
-        sorted_acs = sorted(
-            self.bot.player_mmr.items(),
-            key=lambda x: x[1].get("average_combat_score", 0.0),
-            reverse=True,
-        )
-
-        # Create the view for pages
-        view = LeaderboardView(ctx, self.bot, sorted_acs, players_per_page=10)
-
-        start_index = view.current_page * view.players_per_page
-        end_index = start_index + view.players_per_page
-        page_data = sorted_acs[start_index:end_index]
-
-        names = []
-        leaderboard_data = []
-        for player_id, stats in page_data:
-            user_data = users.find_one({"discord_id": str(player_id)})
-            if user_data:
-                riot_name = user_data.get("name", "Unknown")
-                riot_tag = user_data.get("tag", "Unknown")
-                names.append(f"{riot_name}#{riot_tag}")
-            else:
-                names.append("Unknown")
-
-        for idx, ((player_id, stats), name) in enumerate(
-            zip(page_data, names), start=start_index + 1
-        ):
-            mmr_value = stats["mmr"]
-            wins = stats["wins"]
-            losses = stats["losses"]
-            matches_played = stats.get("matches_played", wins + losses)
-            avg_cs = stats.get("average_combat_score", 0)
-            kd_ratio = stats.get("kill_death_ratio", 0)
-            win_percent = (wins / matches_played * 100) if matches_played > 0 else 0
-
-            leaderboard_data.append(
-                [
-                    idx,
-                    name,
-                    f"{avg_cs:.2f}",
-                    mmr_value,
-                    wins,
-                    losses,
-                    f"{win_percent:.2f}",
-                    f"{kd_ratio:.2f}",
-                ]
-            )
-
-        table_output = t2a(
-            header=["Rank", "User", "Avg ACS", "MMR", "Wins", "Losses", "Win%", "K/D"],
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        self.leaderboard_view_acs = LeaderboardViewACS(
-            ctx, self.bot, sorted_acs, players_per_page=10, timeout=None
-        )
-
-        content = f"## ACS Leaderboard (Page {self.leaderboard_view_acs.current_page+1}/{self.leaderboard_view_acs.total_pages}) ##\n```\n{table_output}\n```"
-        self.leaderboard_message_acs = await ctx.send(
-            content=content, view=self.leaderboard_view_acs
-        )

--- a/views/leaderboard_view.py
+++ b/views/leaderboard_view.py
@@ -1,11 +1,13 @@
 """This view allows users to see a stats leaderboard of all the users currently in the database."""
 
 import math
+from turtledemo.penrose import start
 
 import discord
 from discord.ui import View, Button
 from table2ascii import table2ascii as t2a, PresetStyle
 import wcwidth
+from discord.ui import Select
 
 from database import users, mmr_collection, tdm_mmr_collection
 
@@ -47,15 +49,16 @@ def truncate_by_display_width(original_string, max_width=15, ellipsis=True):
 
 class LeaderboardView(discord.ui.View):
     def __init__(
-        self, ctx, bot, sorted_data, players_per_page=10, timeout=None, mode="normal"
+        self, ctx, bot, sorted_data, sort_by, players_per_page=10, timeout=None, mode="normal"
     ):
         super().__init__(timeout=timeout)
         self.ctx = ctx
         self.bot = bot
+        self.sorted_data = sorted_data
+        self.sort_by = sort_by
         self.players_per_page = players_per_page
         self.current_page = 0
         self.mode = mode  # "normal" or "tdm"
-        self.sorted_data = sorted_data
 
         # Hide users with zero matches
         if self.mode == "tdm":
@@ -67,7 +70,6 @@ class LeaderboardView(discord.ui.View):
         self.total_pages = max(
             1, math.ceil(len(self.sorted_data) / self.players_per_page)
         )
-
         self.previous_button = Button(
             style=discord.ButtonStyle.blurple,
             emoji="⏪",
@@ -96,39 +98,31 @@ class LeaderboardView(discord.ui.View):
         self.add_item(self.next_button)
         self.add_item(self.toggle_mode_button)
 
+
         print(
             f"[LB] mode={self.mode} items={len(self.sorted_data)} per_page={self.players_per_page} pages={self.total_pages}"
         )
 
-    async def on_toggle_mode(self, interaction: discord.Interaction):
-        new_mode = "tdm" if self.mode == "normal" else "normal"
-        collection = tdm_mmr_collection if new_mode == "tdm" else mmr_collection
+    def make_content(self, data, mode, page_count):
+        sort_by_to_title = {
+            "mmr": "MMR",
+            "average_combat_score": "ACS",
+            "kill_death_ratio": "K/D",
+            "wins": "Wins",
+            "losses": "Losses",
+            "tdm_mmr": "MMR"
+        }
 
-        if new_mode == "tdm":
-            sorted_data = sorted(
-                collection.find(), key=lambda x: x.get("tdm_mmr", 0), reverse=True
-            )
-            sorted_data = [d for d in sorted_data if _has_played_tdm(d)]
+        if mode == "tdm":
+            headers = ["Rank", "User", "TDM MMR", "Wins", "Losses", "Avg Kills", "K/D"]
         else:
-            sorted_data = sorted(
-                collection.find(), key=lambda x: x.get("mmr", 0), reverse=True
-            )
-            sorted_data = [d for d in sorted_data if _has_played_normal(d)]
-
-        new_view = LeaderboardView(
-            self.ctx,
-            self.bot,
-            sorted_data,
-            self.players_per_page,
-            timeout=None,
-            mode=new_mode,
-        )
+            headers = ["Rank", "User", "MMR", "Wins", "Losses", "Avg ACS", "K/D"]
 
         leaderboard_data = []
-        start_index = 0
-        end_index = min(self.players_per_page, len(sorted_data))
+        start_index = self.current_page * self.players_per_page
+        end_index = min((self.current_page + 1) * self.players_per_page, len(data))
 
-        for idx, player_data in enumerate(sorted_data[start_index:end_index], start=1):
+        for idx, player_data in enumerate(data[start_index:end_index], start=1):
             player_id = str(player_data["player_id"])
             user_data = users.find_one({"discord_id": player_id})
 
@@ -137,7 +131,7 @@ class LeaderboardView(discord.ui.View):
             else:
                 name = "Unknown"
 
-            if new_mode == "tdm":
+            if mode == "tdm":
                 mmr = player_data.get("tdm_mmr", 1000)
                 wins = player_data.get("tdm_wins", 0)
                 losses = player_data.get("tdm_losses", 0)
@@ -146,7 +140,7 @@ class LeaderboardView(discord.ui.View):
 
                 leaderboard_data.append(
                     [
-                        idx,
+                        idx + start_index,
                         name,
                         mmr,
                         wins,
@@ -163,14 +157,8 @@ class LeaderboardView(discord.ui.View):
                 kd_ratio = player_data.get("kill_death_ratio", 0)
 
                 leaderboard_data.append(
-                    [idx, name, mmr, wins, losses, f"{avg_cs:.2f}", f"{kd_ratio:.2f}"]
+                    [idx + start_index, name, mmr, wins, losses, f"{avg_cs:.2f}", f"{kd_ratio:.2f}"]
                 )
-
-        # Create table
-        if new_mode == "tdm":
-            headers = ["Rank", "User", "TDM MMR", "Wins", "Losses", "Avg Kills", "K/D"]
-        else:
-            headers = ["Rank", "User", "MMR", "Wins", "Losses", "Avg ACS", "K/D"]
 
         table_output = t2a(
             header=headers,
@@ -179,80 +167,49 @@ class LeaderboardView(discord.ui.View):
             style=PresetStyle.thick_compact,
         )
 
-        title = "TDM Leaderboard" if new_mode == "tdm" else "10 Mans Leaderboard"
+        title = "TDM Leaderboard" if mode == "tdm" else f"10 Mans {sort_by_to_title[self.sort_by]} Leaderboard"
         content = (
-            f"## {title} (Page 1/{new_view.total_pages}) ##\n```\n{table_output}\n```"
+            f"## {title} (Page {self.current_page+1}/{page_count}) ##\n```\n{table_output}\n```"
         )
+
+        return content
+
+    async def on_toggle_mode(self, interaction: discord.Interaction):
+        new_mode = "tdm" if self.mode == "normal" else "normal"
+        collection = tdm_mmr_collection if new_mode == "tdm" else mmr_collection
+
+        if new_mode == "tdm":
+            sorted_data = sorted(
+                collection.find(), key=lambda x: x.get("tdm_mmr", 0), reverse=True
+            )
+            sorted_data = [d for d in sorted_data if _has_played_tdm(d)]
+        else:
+            sorted_data = sorted(
+                collection.find(), key=lambda x: x.get(self.sort_by, 0), reverse=True
+            )
+            sorted_data = [d for d in sorted_data if _has_played_normal(d)]
+
+        new_view = LeaderboardView(
+            self.ctx,
+            self.bot,
+            sorted_data,
+            self.sort_by,
+            self.players_per_page,
+            timeout=None,
+            mode=new_mode,
+        )
+
+        self.current_page = new_view.current_page
 
         # Update message
-        await interaction.response.edit_message(content=content, view=new_view)
+        await interaction.response.edit_message(content=self.make_content(sorted_data, new_mode, new_view.total_pages), view=new_view)
 
     async def update_message(self, interaction: discord.Interaction):
-        # Calculate page indexes
-        start_index = self.current_page * self.players_per_page
-        end_index = start_index + self.players_per_page
-        page_data = self.sorted_data[start_index:end_index]
-
-        # Build leaderboard data
-        leaderboard_data = []
-        for idx, stats in enumerate(page_data, start=start_index + 1):
-            user_data = users.find_one({"discord_id": str(stats["player_id"])})
-
-            if user_data:
-                name = f"{user_data.get('name', 'Unknown')}#{user_data.get('tag', 'Unknown')}"
-            else:
-                name = "Unknown"
-
-            if self.mode == "tdm":
-                mmr = stats.get("tdm_mmr", 1000)
-                wins = stats.get("tdm_wins", 0)
-                losses = stats.get("tdm_losses", 0)
-                avg_kills = stats.get("tdm_avg_kills", 0)
-                kd_ratio = stats.get("tdm_kd_ratio", 0)
-
-                leaderboard_data.append(
-                    [
-                        idx,
-                        name,
-                        mmr,
-                        wins,
-                        losses,
-                        f"{avg_kills:.1f}",
-                        f"{kd_ratio:.2f}",
-                    ]
-                )
-            else:
-                mmr = stats.get("mmr", 1000)
-                wins = stats.get("wins", 0)
-                losses = stats.get("losses", 0)
-                avg_cs = stats.get("average_combat_score", 0)
-                kd_ratio = stats.get("kill_death_ratio", 0)
-
-                leaderboard_data.append(
-                    [idx, name, mmr, wins, losses, f"{avg_cs:.2f}", f"{kd_ratio:.2f}"]
-                )
-
-        # Create table header based on mode
-        if self.mode == "tdm":
-            headers = ["Rank", "User", "TDM MMR", "Wins", "Losses", "Avg Kills", "K/D"]
-        else:
-            headers = ["Rank", "User", "MMR", "Wins", "Losses", "Avg ACS", "K/D"]
-
-        table_output = t2a(
-            header=headers,
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        title = "TDM Leaderboard" if self.mode == "tdm" else "10 Mans Leaderboard"
-        content = f"## {title} (Page {self.current_page + 1}/{self.total_pages}) ##\n```\n{table_output}\n```"
-
         # Update button states
         self.previous_button.disabled = self.current_page == 0
         self.next_button.disabled = self.current_page >= self.total_pages - 1
 
-        await interaction.response.edit_message(content=content, view=self)
+        await interaction.response.edit_message(content=self.make_content(self.sorted_data, self.mode, self.total_pages), view=self)
 
     async def on_previous(self, interaction: discord.Interaction):
         if self.current_page > 0:
@@ -273,7 +230,7 @@ class LeaderboardView(discord.ui.View):
             )
         else:
             self.sorted_data = sorted(
-                collection.find(), key=lambda x: x.get("mmr", 0), reverse=True
+                collection.find(), key=lambda x: x.get(self.sort_by, 0), reverse=True
             )
         if self.mode == "tdm":
             self.sorted_data = [d for d in self.sorted_data if _has_played_tdm(d)]
@@ -283,286 +240,4 @@ class LeaderboardView(discord.ui.View):
         self.total_pages = math.ceil(len(self.sorted_data) / self.players_per_page)
         if self.current_page >= self.total_pages:
             self.current_page = max(0, self.total_pages - 1)
-        await self.update_message(interaction)
-
-
-class LeaderboardViewKD(View):
-    def __init__(self, ctx, bot, sorted_kd, players_per_page=10, timeout=None):
-        super().__init__(timeout=timeout)
-        self.ctx = ctx
-        self.bot = bot
-        self.sorted_mmr = sorted_kd
-        self.players_per_page = players_per_page
-        self.current_page = 0
-        self.total_pages = math.ceil(len(self.sorted_mmr) / self.players_per_page)
-
-        self.previous_button.disabled = True
-        self.next_button.disabled = (
-            self.total_pages == 1
-        )  # If only one page, disable next
-
-    async def update_message(self, interaction: discord.Interaction):
-        start_index = self.current_page * self.players_per_page
-        end_index = start_index + self.players_per_page
-        page_data = self.sorted_mmr[start_index:end_index]
-
-        # make the leaderboard table for the page
-        leaderboard_data = []
-        names = []
-        for player_id, stats in page_data:
-            user_data = users.find_one({"discord_id": str(player_id)})
-            if user_data:
-                riot_name = user_data.get("name", "Unknown")
-                riot_tag = user_data.get("tag", "Unknown")
-                names.append(f"{riot_name}#{riot_tag}")
-            else:
-                names.append("Unknown")
-
-        for idx, ((player_id, stats), name) in enumerate(
-            zip(page_data, names), start=start_index + 1
-        ):
-            mmr_value = stats["mmr"]
-            wins = stats["wins"]
-            losses = stats["losses"]
-            matches_played = stats.get("matches_played", wins + losses)
-            avg_cs = stats.get("average_combat_score", 0)
-            kd_ratio = stats.get("kill_death_ratio", 0)
-            win_percent = (wins / matches_played * 100) if matches_played > 0 else 0
-
-            leaderboard_data.append(
-                [
-                    idx,
-                    name,
-                    f"{kd_ratio:.2f}",
-                    mmr_value,
-                    wins,
-                    losses,
-                    f"{win_percent:.2f}",
-                    f"{avg_cs:.2f}",
-                ]
-            )
-
-        table_output = t2a(
-            header=["Rank", "User", "K/D", "MMR", "Wins", "Losses", "Win%", "Avg ACS"],
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        content = f"## K/D Leaderboard (Page {self.current_page + 1}/{self.total_pages}) ##\n```\n{table_output}\n```"
-
-        # Update button based on the current page
-        self.previous_button.disabled = self.current_page == 0
-        self.next_button.disabled = self.current_page == self.total_pages - 1
-
-        await interaction.response.edit_message(content=content, view=self)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, disabled=True, emoji="⏪")
-    async def previous_button(self, interaction: discord.Interaction):
-        self.current_page -= 1
-        await self.update_message(interaction)
-
-    # Refresh the leaderboard
-    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji="🔄")
-    async def refresh_button(self, interaction: discord.Interaction):
-        self.sorted_mmr = sorted(
-            self.bot.player_mmr.items(),
-            key=lambda x: x[1].get("kill_death_ratio", 0.0),
-            reverse=True,
-        )
-
-        self.total_pages = math.ceil(len(self.sorted_mmr) / self.players_per_page)
-        if self.current_page >= self.total_pages:
-            self.current_page = max(0, self.total_pages - 1)
-
-        await self.update_message(interaction)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, disabled=False, emoji="⏩")
-    async def next_button(self, interaction: discord.Interaction):
-        self.current_page += 1
-        await self.update_message(interaction)
-
-
-class LeaderboardViewWins(View):
-    def __init__(self, ctx, bot, sorted_wins, players_per_page=10, timeout=None):
-        super().__init__(timeout=timeout)
-        self.ctx = ctx
-        self.bot = bot
-        self.sorted_mmr = sorted_wins
-        self.players_per_page = players_per_page
-        self.current_page = 0
-        self.total_pages = math.ceil(len(self.sorted_mmr) / self.players_per_page)
-
-        self.previous_button.disabled = True  # can't go back
-        self.next_button.disabled = self.total_pages == 1
-
-    async def update_message(self, interaction: discord.Interaction):
-        start_index = self.current_page * self.players_per_page
-        end_index = start_index + self.players_per_page
-        page_data = self.sorted_mmr[start_index:end_index]
-
-        leaderboard_data = []
-        names = []
-        for player_id, stats in page_data:
-            user_data = users.find_one({"discord_id": str(player_id)})
-            if user_data:
-                riot_name = user_data.get("name", "Unknown")
-                riot_tag = user_data.get("tag", "Unknown")
-                names.append(f"{riot_name}#{riot_tag}")
-            else:
-                names.append("Unknown")
-
-        for idx, ((player_id, stats), name) in enumerate(
-            zip(page_data, names), start=start_index + 1
-        ):
-            mmr_value = stats["mmr"]
-            wins = stats["wins"]
-            losses = stats["losses"]
-            matches_played = stats.get("matches_played", wins + losses)
-            avg_cs = stats.get("average_combat_score", 0)
-            kd_ratio = stats.get("kill_death_ratio", 0)
-            win_percent = (wins / matches_played * 100) if matches_played > 0 else 0
-
-            leaderboard_data.append(
-                [
-                    idx,
-                    name,
-                    wins,
-                    mmr_value,
-                    losses,
-                    f"{win_percent:.2f}",
-                    f"{avg_cs:.2f}",
-                    f"{kd_ratio:.2f}",
-                ]
-            )
-
-        table_output = t2a(
-            header=["Rank", "User", "Wins", "MMR", "Losses", "Win%", "Avg ACS", "K/D"],
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        content = f"## Wins Leaderboard (Page {self.current_page + 1}/{self.total_pages}) ##\n```\n{table_output}\n```"
-
-        self.previous_button.disabled = self.current_page == 0
-        self.next_button.disabled = self.current_page == self.total_pages - 1
-
-        await interaction.response.edit_message(content=content, view=self)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, disabled=True, emoji="⏪")
-    async def previous_button(self, interaction: discord.Interaction):
-        self.current_page -= 1
-        await self.update_message(interaction)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji="🔄")
-    async def refresh_button(self, interaction: discord.Interaction):
-        self.sorted_mmr = sorted(
-            self.bot.player_mmr.items(),
-            key=lambda x: x[1].get("wins", 0.0),  # Default to 0.0 if key is missing
-            reverse=True,
-        )
-
-        # Recalculate total_pages if player count changed
-        self.total_pages = math.ceil(len(self.sorted_mmr) / self.players_per_page)
-        if self.current_page >= self.total_pages:
-            self.current_page = max(0, self.total_pages - 1)
-
-        await self.update_message(interaction)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, disabled=False, emoji="⏩")
-    async def next_button(self, interaction: discord.Interaction):
-        self.current_page += 1
-        await self.update_message(interaction)
-
-
-class LeaderboardViewACS(View):
-    def __init__(self, ctx, bot, sorted_acs, players_per_page=10, timeout=None):
-        super().__init__(timeout=timeout)
-        self.ctx = ctx
-        self.bot = bot
-        self.sorted_mmr = sorted_acs
-        self.players_per_page = players_per_page
-        self.current_page = 0
-        self.total_pages = math.ceil(len(self.sorted_mmr) / self.players_per_page)
-
-        self.previous_button.disabled = True
-        self.next_button.disabled = self.total_pages == 1
-
-    async def update_message(self, interaction: discord.Interaction):
-        start_index = self.current_page * self.players_per_page
-        end_index = start_index + self.players_per_page
-        page_data = self.sorted_mmr[start_index:end_index]
-
-        leaderboard_data = []
-        names = []
-        for player_id, stats in page_data:
-            user_data = users.find_one({"discord_id": str(player_id)})
-            if user_data:
-                riot_name = user_data.get("name", "Unknown")
-                riot_tag = user_data.get("tag", "Unknown")
-                names.append(f"{riot_name}#{riot_tag}")
-            else:
-                names.append("Unknown")
-
-        for idx, ((player_id, stats), name) in enumerate(
-            zip(page_data, names), start=start_index + 1
-        ):
-            mmr_value = stats["mmr"]
-            wins = stats["wins"]
-            losses = stats["losses"]
-            matches_played = stats.get("matches_played", wins + losses)
-            avg_cs = stats.get("average_combat_score", 0)
-            kd_ratio = stats.get("kill_death_ratio", 0)
-            win_percent = (wins / matches_played * 100) if matches_played > 0 else 0
-
-            leaderboard_data.append(
-                [
-                    idx,
-                    name,
-                    f"{avg_cs:.2f}",
-                    mmr_value,
-                    wins,
-                    losses,
-                    f"{win_percent:.2f}",
-                    f"{kd_ratio:.2f}",
-                ]
-            )
-
-        table_output = t2a(
-            header=["Rank", "User", "Avg ACS", "MMR", "Wins", "Losses", "Win%", "K/D"],
-            body=leaderboard_data,
-            first_col_heading=True,
-            style=PresetStyle.thick_compact,
-        )
-
-        content = f"## ACS Leaderboard (Page {self.current_page + 1}/{self.total_pages}) ##\n```\n{table_output}\n```"
-
-        self.previous_button.disabled = self.current_page == 0
-        self.next_button.disabled = self.current_page == self.total_pages - 1
-
-        await interaction.response.edit_message(content=content, view=self)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, disabled=True, emoji="⏪")
-    async def previous_button(self, interaction: discord.Interaction):
-        self.current_page -= 1
-        await self.update_message(interaction)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, emoji="🔄")
-    async def refresh_button(self, interaction: discord.Interaction):
-        self.sorted_mmr = sorted(
-            self.bot.player_mmr.items(),
-            key=lambda x: x[1].get("average_combat_score", 0.0),
-            reverse=True,
-        )
-
-        self.total_pages = math.ceil(len(self.sorted_mmr) / self.players_per_page)
-        if self.current_page >= self.total_pages:
-            self.current_page = max(0, self.total_pages - 1)
-
-        await self.update_message(interaction)
-
-    @discord.ui.button(style=discord.ButtonStyle.blurple, disabled=False, emoji="⏩")
-    async def next_button(self, interaction: discord.Interaction):
-        self.current_page += 1
         await self.update_message(interaction)


### PR DESCRIPTION
Consolidated the types of leaderboards (mmr, wins, losses, acs, kd) into one leaderboard view which now takes a sort_by parameter from the user to determine how to order the leaderboard.

Usage has been updated in !help.

Fixes #80